### PR TITLE
Custom error grouping with Raygun

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,20 @@ Custom Raygun client settings (http://raygun.io/docs/Languages#net)
 var client = Raygun.Diagnostics.Settings.Client;
 ```
 
+Custom error grouping is available by using an anonymous type with a "GroupKey" property
+```c#
+public void MyMethod()
+{
+	try{}
+	catch(Exception e)
+	{
+		// aggregate all errors of type MyCustomGroupKey together
+        Trace.TraceError("something bad happened", e, new { GroupKey = "MyCustomGroupKey" });
+	}
+}
+
+```
+
 Other settings
 ```c#
 // enable debug specific options for tracing

--- a/src/Raygun.Diagnostics.Tests/Models/MockRaygunClient.cs
+++ b/src/Raygun.Diagnostics.Tests/Models/MockRaygunClient.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Mindscape.Raygun4Net;
+using Mindscape.Raygun4Net.Messages;
+
+namespace Raygun.Diagnostics.Tests.Models
+{
+    class MockRaygunClient : RaygunClient
+    {
+
+        public override void Send(RaygunMessage raygunMessage)
+        {
+            //Fire the event to tell the library to propagate the event down the subscription change
+            //OnCustomGroupingKey(new Exception(raygunMessage.ToString()), raygunMessage);            
+        }
+
+        public override void Send(Exception exception)
+        {
+            //do nothing here so we don't actually send the message
+        }
+
+    }
+}

--- a/src/Raygun.Diagnostics.Tests/Raygun.Diagnostics.Tests.csproj
+++ b/src/Raygun.Diagnostics.Tests/Raygun.Diagnostics.Tests.csproj
@@ -67,6 +67,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="HelperFixture.cs" />
+    <Compile Include="Models\MockRaygunClient.cs" />
     <Compile Include="Models\MockUser.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TraceListenerFromStringFixture.cs" />

--- a/src/Raygun.Diagnostics.net35/Properties/AssemblyInfo.cs
+++ b/src/Raygun.Diagnostics.net35/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0")]
-[assembly: AssemblyFileVersion("1.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0")]
+[assembly: AssemblyVersion("1.1.0")]
+[assembly: AssemblyFileVersion("1.1.0")]
+[assembly: AssemblyInformationalVersion("1.1.0")]

--- a/src/Raygun.Diagnostics.net35/Raygun.Diagnostics.net35.csproj
+++ b/src/Raygun.Diagnostics.net35/Raygun.Diagnostics.net35.csproj
@@ -48,11 +48,17 @@
     <Compile Include="..\Raygun.Diagnostics\Helpers\ValidationExtensions.cs">
       <Link>Helpers\ValidationExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\Raygun.Diagnostics\Models\IMessageGroup.cs">
+      <Link>Models\IMessageGroup.cs</Link>
+    </Compile>
     <Compile Include="..\Raygun.Diagnostics\Models\IUserInfo.cs">
       <Link>Models\IUserInfo.cs</Link>
     </Compile>
     <Compile Include="..\Raygun.Diagnostics\Models\MessageContext.cs">
       <Link>Models\MessageContext.cs</Link>
+    </Compile>
+    <Compile Include="..\Raygun.Diagnostics\Models\MessageGroup.cs">
+      <Link>Models\MessageGroup.cs</Link>
     </Compile>
     <Compile Include="..\Raygun.Diagnostics\Models\MessageTraceLevel.cs">
       <Link>Models\MessageTraceLevel.cs</Link>

--- a/src/Raygun.Diagnostics.net40/Properties/AssemblyInfo.cs
+++ b/src/Raygun.Diagnostics.net40/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0")]
-[assembly: AssemblyFileVersion("1.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0")]
+[assembly: AssemblyVersion("1.1.0")]
+[assembly: AssemblyFileVersion("1.1.0")]
+[assembly: AssemblyInformationalVersion("1.1.0")]

--- a/src/Raygun.Diagnostics.net40/Raygun.Diagnostics.net40.csproj
+++ b/src/Raygun.Diagnostics.net40/Raygun.Diagnostics.net40.csproj
@@ -53,11 +53,17 @@
     <Compile Include="..\Raygun.Diagnostics\Helpers\ValidationExtensions.cs">
       <Link>Helpers\ValidationExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\Raygun.Diagnostics\Models\IMessageGroup.cs">
+      <Link>Models\IMessageGroup.cs</Link>
+    </Compile>
     <Compile Include="..\Raygun.Diagnostics\Models\IUserInfo.cs">
       <Link>Models\IUserInfo.cs</Link>
     </Compile>
     <Compile Include="..\Raygun.Diagnostics\Models\MessageContext.cs">
       <Link>Models\MessageContext.cs</Link>
+    </Compile>
+    <Compile Include="..\Raygun.Diagnostics\Models\MessageGroup.cs">
+      <Link>Models\MessageGroup.cs</Link>
     </Compile>
     <Compile Include="..\Raygun.Diagnostics\Models\MessageTraceLevel.cs">
       <Link>Models\MessageTraceLevel.cs</Link>

--- a/src/Raygun.Diagnostics/Models/IMessageGroup.cs
+++ b/src/Raygun.Diagnostics/Models/IMessageGroup.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Raygun.Diagnostics.Models
+{
+    public interface IMessageGroup
+    {
+        string GroupKey { get; set; }
+
+    }
+}

--- a/src/Raygun.Diagnostics/Models/MessageContext.cs
+++ b/src/Raygun.Diagnostics/Models/MessageContext.cs
@@ -33,7 +33,7 @@ namespace Raygun.Diagnostics.Models
     /// Message used for custom hash grouping when sending the error to Raygun.  Raygun does their own examination of the data sent to group errors in sometimes unintended ways.
     /// This allows the calling application to control the grouping.
     /// </summary>
-    public IMessageGroup Grouping { get; set; }
+    public IMessageGroup Group { get; set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MessageContext" /> class.
@@ -48,6 +48,7 @@ namespace Raygun.Diagnostics.Models
       Tags = tags;
       Data = data;
       User = user;
+      Group = new MessageGroup();
     }
 
     /// <summary>

--- a/src/Raygun.Diagnostics/Models/MessageContext.cs
+++ b/src/Raygun.Diagnostics/Models/MessageContext.cs
@@ -28,6 +28,12 @@ namespace Raygun.Diagnostics.Models
     /// </summary>
     /// <value>The user.</value>
     public IUserInfo User { get; set; }
+    
+    /// <summary>
+    /// Message used for custom hash grouping when sending the error to Raygun.  Raygun does their own examination of the data sent to group errors in sometimes unintended ways.
+    /// This allows the calling application to control the grouping.
+    /// </summary>
+    public IMessageGroup Grouping { get; set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MessageContext" /> class.
@@ -60,6 +66,6 @@ namespace Raygun.Diagnostics.Models
         FirstName = User.FirstName,
         IsAnonymous = User.IsAnonymous
       };
-    }
+    }       
   }
 }

--- a/src/Raygun.Diagnostics/Models/MessageGroup.cs
+++ b/src/Raygun.Diagnostics/Models/MessageGroup.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Raygun.Diagnostics.Models
+{
+    public class MessageGroup : IMessageGroup
+    {
+        public string GroupKey { get; set; }
+        public MessageGroup()
+        {
+            GroupKey = string.Empty;
+        }
+    }
+}

--- a/src/Raygun.Diagnostics/Properties/AssemblyInfo.cs
+++ b/src/Raygun.Diagnostics/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0")]
-[assembly: AssemblyFileVersion("1.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0")]
+[assembly: AssemblyVersion("1.1.0")]
+[assembly: AssemblyFileVersion("1.1.0")]
+[assembly: AssemblyInformationalVersion("1.1.0")]

--- a/src/Raygun.Diagnostics/Raygun.Diagnostics.csproj
+++ b/src/Raygun.Diagnostics/Raygun.Diagnostics.csproj
@@ -50,6 +50,8 @@
   <ItemGroup>
     <Compile Include="Helpers\MessageExtensions.cs" />
     <Compile Include="Helpers\ValidationExtensions.cs" />
+    <Compile Include="Models\MessageGroup.cs" />
+    <Compile Include="Models\IMessageGroup.cs" />
     <Compile Include="Models\MessageContext.cs" />
     <Compile Include="Models\MessageTraceLevel.cs" />
     <Compile Include="Models\IUserInfo.cs" />

--- a/src/Raygun.Diagnostics/Raygun.Diagnostics.nuspec
+++ b/src/Raygun.Diagnostics/Raygun.Diagnostics.nuspec
@@ -11,9 +11,7 @@
     <iconUrl>https://raw.githubusercontent.com/sirkirby/raygun.diagnostics/master/pkglogo.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>$description$</description>
-    <releaseNotes>- Moving from preview to v1 release
-- Raygun user/identity support via custom argument or through new RaygunDiagnosticsUserAttribute
-- Created NUnit unit tests for helpers and main trace listener functionality
+    <releaseNotes>Added override functionality for custom error message grouping.
     </releaseNotes>
     <copyright>Copyright Chris Kirby 2015</copyright>
     <tags>Raygun diagnostics tracing debug</tags>

--- a/src/Raygun.Diagnostics/RaygunTraceListener.cs
+++ b/src/Raygun.Diagnostics/RaygunTraceListener.cs
@@ -167,8 +167,12 @@ namespace Raygun.Diagnostics
         if (Settings.DefaultTags != null)
           message.Tags.AddRange(Settings.DefaultTags);
 
-        //Set the event handler to automatically handle custom grouping logic
-        Settings.Client.CustomGroupingKey += (sender, e) => { HandleGrouping(sender, e, message.Grouping); };
+        //Set the event handler to automatically handle custom grouping
+        if (message.Group != null)
+        {
+            Settings.Client.CustomGroupingKey += (sender, e) => { HandleGrouping(sender, e, message.Group); };
+        }
+                
         Settings.Client.Send(message.Exception, message.Tags, message.Data, message.GetRaygunUser());
       }
       catch (Exception e)
@@ -178,12 +182,12 @@ namespace Raygun.Diagnostics
       }
     }
 
-    private void HandleGrouping(object sender, RaygunCustomGroupingKeyEventArgs e, IMessageGroup grouping)
+    private void HandleGrouping(object sender, RaygunCustomGroupingKeyEventArgs e, IMessageGroup group)
     {
         //Only override the grouping if specified
-        if (!String.IsNullOrEmpty(grouping.GroupKey))
+        if (!String.IsNullOrEmpty(group.GroupKey))
         {
-            e.CustomGroupingKey = grouping.GroupKey;
+            e.CustomGroupingKey = group.GroupKey;
         }        
     }
 
@@ -308,7 +312,7 @@ namespace Raygun.Diagnostics
           var grouping = localArgs.FirstOrDefault(a => a.HasProperty("groupkey"));
           if (grouping != null)
           {
-              context.Grouping = GetGrouping(grouping);
+              context.Group = GetGrouping(grouping);
               localArgs.Remove(grouping);
           }
 

--- a/src/Raygun.Diagnostics/RaygunTraceListener.cs
+++ b/src/Raygun.Diagnostics/RaygunTraceListener.cs
@@ -12,8 +12,12 @@ using Raygun.Diagnostics.Models;
 
 namespace Raygun.Diagnostics
 {
+  public delegate void Grouped(object sender, RaygunCustomGroupingKeyEventArgs e, IMessageGroup group);
   public class RaygunTraceListener : TraceListener
   {
+
+    public event Grouped OnGrouping;
+
     /// <summary>
     /// Checks for other trace listeners
     /// </summary>
@@ -21,7 +25,7 @@ namespace Raygun.Diagnostics
     {
       // see if others are listening
       return (Trace.Listeners != null && Trace.Listeners["RaygunTraceListener"] != null && Trace.Listeners.Count > 1);
-    }
+    }    
 
     /// <summary>
     /// Emits an error message to Raygun.
@@ -181,14 +185,22 @@ namespace Raygun.Diagnostics
           Trace.TraceError("Error on Raygun Send() : {0}", e.Message);
       }
     }
-
+    
+    /// <summary>
+    /// Method used to bind to the CustomGroupingKey event of the RaygunClient object
+    /// </summary>
+    /// <param name="sender">the Raygun client object firing the event</param>
+    /// <param name="e">The custom group arguments of the RaygunClient message</param>
+    /// <param name="group">The message group that contains the data to tell the Raygun client how to group the message</param>
     private void HandleGrouping(object sender, RaygunCustomGroupingKeyEventArgs e, IMessageGroup group)
     {
         //Only override the grouping if specified
         if (!String.IsNullOrEmpty(group.GroupKey))
         {
             e.CustomGroupingKey = group.GroupKey;
-        }        
+        }
+
+        OnGrouping?.Invoke(sender, e, group);
     }
 
     /// <summary>

--- a/src/Raygun.Diagnostics/Settings.cs
+++ b/src/Raygun.Diagnostics/Settings.cs
@@ -21,6 +21,7 @@ namespace Raygun.Diagnostics
     public static RaygunClient Client
     {
       get { return _client ?? (_client = ApiKey == null ? new RaygunClient() : new RaygunClient(ApiKey)); }
+      set { _client = value; }
     }
 
     /// <summary>


### PR DESCRIPTION
- new classes IMessageGroup and MessageGroup to pass grouping data between the library and the calling application
- new support for passing custom grouping info anonymously
- updated readme to include usage of custom grouping
- updated version number and nuspec file.